### PR TITLE
module_bundler.py: Fixes for Windows

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,4 +3,5 @@ The following authors have make contributions to this project, and agree to
 make their contributions available under the terms of the project license:
 
 * Ryan Kelly <ryan@rfk.id.au>
+* Ian Meikle
 

--- a/tools/module_bundler.py
+++ b/tools/module_bundler.py
@@ -410,7 +410,7 @@ class ModuleBundle(object):
             modname = package + "." + modname
         if not self.is_excluded(modname):
             # Add it to the list of available modules.
-            moddata = {"file": relpath}
+            moddata = {"file": relpath.replace("\\", "/")}
             self.modules[modname] = moddata
             # Copy its source file across.
             self._copy_py_file(os.path.join(rootdir, relpath),
@@ -432,7 +432,7 @@ class ModuleBundle(object):
             subpackage = package + "." + subpackage
         if not self.is_excluded(subpackage):
             # Note it as an available package.
-            self.modules[subpackage] = {"dir": relpath}
+            self.modules[subpackage] = {"dir": relpath.replace("\\", "/")}
             if not os.path.isdir(os.path.join(self.bundle_dir, relpath)):
                 os.makedirs(os.path.join(self.bundle_dir, relpath))
             # Include it in post-gathering analysis.


### PR DESCRIPTION
Atomic renames don't work in Windows if a file already exists at the destination, so `flush_index` will fail on Windows. This little tweak fixes that.

This PR will also have the script change Windows slashes to Unix ones