### PR TITLE
don't use `print` to debug

### DIFF
--- a/lib/pypy.js
+++ b/lib/pypy.js
@@ -23,8 +23,8 @@ if (typeof module !== "undefined") {
 var debug = function(){};
 if (typeof console !== "undefined") {
   debug = console.log;
-} else if (typeof print !== "undefined") {
-  debug = print
+} else if (typeof print !== "undefined" && typeof window === "undefined") {
+  debug = print;
 }
 
 
@@ -101,9 +101,27 @@ function PyPyJS(opts) {
       this.stderr = function(x) { process.stderr.write(x); }
     }
   }
-  if (typeof print !== "undefined") {
+  var _print, _printErr;
+  if (typeof window === "undefined") {
+    // print, printErr from v8, spidermonkey
+    if (tyepof print !== "undefined") {
+      _print = print;
+    }
+    if (typeof printErr !== "undefined") {
+      _printErr = printErr;
+    }
+  }
+  if (typeof console !== "undefined") {
+    if (typeof _print === "undefined") {
+      _print = console.log;
+    }
+    if (typeof _printErr === "undefined") {
+      _printErr = console.error;
+    }
+  }
+  if (typeof _print !== "undefined") {
     if (this.stdout === null) {
-      // print() will add a newline, so we buffer until we
+      // print()/console.log() will add a newline, so we buffer until we
       // receive one and then let it add it for us.
       this.stdout = (function() {
         var buffer = [];
@@ -113,7 +131,7 @@ function PyPyJS(opts) {
             if (x !== "\n") {
               buffer.push(x);
             } else {
-              print(buffer.join(""));
+              _print(buffer.join(""));
               buffer.splice(undefined, buffer.length);
             }
           }
@@ -121,9 +139,9 @@ function PyPyJS(opts) {
       })();
     }
   }
-  if (typeof printErr !== "undefined") {
+  if (typeof _printErr !== "undefined") {
     if (this.stderr === null) {
-      // printErr() will add a newline, so we buffer until we
+      // printErr()/console.error() will add a newline, so we buffer until we
       // receive one and then let it add it for us.
       this.stderr = (function() {
         var buffer = [];
@@ -133,7 +151,7 @@ function PyPyJS(opts) {
             if (x !== "\n") {
               buffer.push(x);
             } else {
-              printErr(buffer.join(""));
+              _printErr(buffer.join(""));
               buffer.splice(undefined, buffer.length);
             }
           }


### PR DESCRIPTION
`print()` is defined and invokes a print dialog on Chrome