### PR TITLE
check if window is undefined for nodejs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -6,4 +6,5 @@ make their contributions available under the terms of the project license:
 * Ian Meikle
 * Buck Evan <buck.2019@gmail.com>
 * Jason Kraus
+* Min RK
 

--- a/lib/pypy.js
+++ b/lib/pypy.js
@@ -74,7 +74,7 @@ if (typeof Promise === "undefined") {
 }
 
 // Some extra goodies for nodejs.
-if (typeof require === "function") {
+if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
   var fs = require("fs");
   var path = require("path");
 }


### PR DESCRIPTION
`require` is defined and a function when pypy.js loaded with require.js in a browser,
causing `require("fs")` to fail.