### PR TITLE
Add handling for Project Spartan tracebacks

### DIFF
--- a/lib/pypy.js
+++ b/lib/pypy.js
@@ -36,7 +36,7 @@ if (typeof __dirname === "undefined") {
   // Throw an error, then parse the stack trace looking for filenames.
   var errlines = (new Error()).stack.split("\n");
   for (var i = 0; i < errlines.length; i++) {
-    var match = /(at |@)(.+\/)pypy.js/.exec(errlines[i]);
+    var match = /(at Anonymous function \(|at |@)(.+\/)pypy.js/.exec(errlines[i]);
     if (match) {
       __dirname = match[2];
       break;


### PR DESCRIPTION
Fixes #80.

Here's what one looks like, for reference:

```
Error
   at Anonymous function (http://127.0.0.1:8000/js/pypy.js-0.2.0/lib/pypy.js:37:3)
   at Global code (http://127.0.0.1:8000/js/pypy.js-0.2.0/lib/pypy.js:5:2)
```

I haven't tried this in IE yet, so I'm not sure if this is what IE tracebacks look like too